### PR TITLE
Use service client only when service role key is available

### DIFF
--- a/app/api/admin/prompts/route.ts
+++ b/app/api/admin/prompts/route.ts
@@ -86,9 +86,10 @@ export async function POST(req: NextRequest) {
     businessValue: businessPrompt,
     toolsAutomation: toolsPrompt
   };
-  // Use a service client to bypass RLS on admin_settings if needed
-  const supabaseService = createServerSupabaseClient();
-  const supabase = supabaseService ?? supabaseUser;
+  // Use a service client to bypass RLS on admin_settings if the service key is available
+  const supabase = process.env.SUPABASE_SERVICE_ROLE_KEY
+    ? createServerSupabaseClient()
+    : supabaseUser;
   const { error: updateError } = await supabase
     .from('admin_settings')
     .update({ prompts: newPrompts })


### PR DESCRIPTION
## Summary
- only instantiate the service-role Supabase client when the service key is configured
- fall back to the authenticated user client for updating admin settings so RLS still succeeds without a service key

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e081ca11d88323b6e7e0319769dada